### PR TITLE
Strip spaces from column names

### DIFF
--- a/src/import_gtfs_to_sql.py
+++ b/src/import_gtfs_to_sql.py
@@ -112,7 +112,7 @@ def import_file(fname, tablename, handler, COPY=True):
     handler = SpecialHandler()
 
   reader = csv.reader(f,dialect=csv.excel);
-  header = handler.handleCols(reader.next());
+  header = handler.handleCols([c.strip() for c in reader.next()]);
   cols = ",".join(header);
 
   defaultVal = 'NULL';


### PR DESCRIPTION
I ran into an issue where my GTFS had a leading space in the values of the header row. In my particular case, the script bombed on line 70 because the key 'arrival_time' didn't exist, only ' arrival_time'. I just added a list comprehension to strip all of the header values.
