### PR TITLE
Added feed_start_date and feed_end_date columns to gtfs_feed_info sqlite

### DIFF
--- a/src/gtfs_tables.sqlite
+++ b/src/gtfs_tables.sqlite
@@ -311,6 +311,8 @@ create table gtfs_feed_info (
   feed_publisher_name text,
   feed_publisher_url text,
   feed_timezone text,
+  feed_start_date text,
+  feed_end_date text,  
   feed_lang text,
   feed_version text
 );


### PR DESCRIPTION
These two columns are missing from the tables and are specified in the official specs (https://developers.google.com/transit/gtfs/reference#feed_info_fields). Some feeds like Boston's MBTA (http://www.mbta.com/uploadedfiles/MBTA_GTFS.zip) use these fields and were throwing errors.
